### PR TITLE
Added missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@nomicfoundation/hardhat-verify": "^2.0.0",
     "@nomiclabs/hardhat-truffle5": "^2.0.7",
     "@nomiclabs/hardhat-web3": "^2.0.0",
+    "@openzeppelin/test-helpers": "^0.5.16",
     "@typechain/ethers-v6": "^0.5.0",
     "@typechain/hardhat": "^9.0.0",
     "@typechain/truffle-v5": "^8.0.7",


### PR DESCRIPTION
`npx hardhat test` was failing because there was a missing dependency.