### PR TITLE
add(ftso): example of using desired anchor feeds manually

### DIFF
--- a/contracts/FTSOAnchorConsumer.sol
+++ b/contracts/FTSOAnchorConsumer.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0 <0.9.0;
+
+import {FtsoV2Interface} from "@flarenetwork/flare-periphery-contracts/coston2/FtsoV2Interface.sol";
+import {ContractRegistry} from "@flarenetwork/flare-periphery-contracts/coston2/ContractRegistry.sol";
+import {TestFtsoV2Interface} from "@flarenetwork/flare-periphery-contracts/coston2/TestFtsoV2Interface.sol";
+
+/**
+ * THIS IS AN EXAMPLE CONTRACT.
+ * DO NOT USE THIS CODE IN PRODUCTION.
+ */
+contract FtsoV2AnchorFeedConsumer {
+    bytes21 private constant FLR_USD_ID =
+        0x01464c522f55534400000000000000000000000000;
+    bytes21 private constant BTC_USD_ID =
+        0x014254432f55534400000000000000000000000000;
+    bytes21 private constant ETH_USD_ID =
+        0x014554482f55534400000000000000000000000000;
+    mapping(uint32 => mapping(bytes21 => TestFtsoV2Interface.FeedData))
+        public provenFeeds;
+
+    // Track which feeds have been proven per round for easy enumeration
+    mapping(uint32 => bytes21[]) private _provenFeedIdsByRound;
+    mapping(uint32 => mapping(bytes21 => bool)) private _isProven;
+
+    event FeedProven(
+        uint32 indexed votingRoundId,
+        bytes21 indexed id,
+        int32 value,
+        uint16 turnoutBIPS,
+        int8 decimals
+    );
+
+    function savePrice(
+        TestFtsoV2Interface.FeedDataWithProof calldata data
+    ) external {
+        /* THIS IS A TEST METHOD, in production use: ftsoV2 = ContractRegistry.getFtsoV2(); */
+        TestFtsoV2Interface ftsoV2 = ContractRegistry.getTestFtsoV2();
+        // Step 1: Verify the proof
+        require(ftsoV2.verifyFeedData(data), "Invalid proof");
+
+        // Step 2: Ensure the proof is for the desired feedId tp avoid manipulation
+        require(
+            data.body.id == FLR_USD_ID ||
+                data.body.id == BTC_USD_ID ||
+                data.body.id == ETH_USD_ID,
+            "Proof is not for desired feedId"
+        );
+        // Step 3: Use the feed data with app specific logic
+        // Here the feed data is saved
+        uint32 roundId = data.body.votingRoundId;
+        bytes21 id = data.body.id;
+        provenFeeds[roundId][id] = data.body;
+
+        // Record id for enumeration if first time proven in this round
+        if (!_isProven[roundId][id]) {
+            _isProven[roundId][id] = true;
+            _provenFeedIdsByRound[roundId].push(id);
+        }
+
+        emit FeedProven(
+            roundId,
+            id,
+            data.body.value,
+            data.body.turnoutBIPS,
+            data.body.decimals
+        );
+    }
+
+    // Returns whether a given feed id has been proven for the round
+    function isProven(
+        uint32 votingRoundId,
+        bytes21 id
+    ) external view returns (bool) {
+        return _isProven[votingRoundId][id];
+    }
+
+    // Returns all feed ids proven for a voting round
+    function getProvenFeedIds(
+        uint32 votingRoundId
+    ) external view returns (bytes21[] memory) {
+        return _provenFeedIdsByRound[votingRoundId];
+    }
+
+    // Returns all proven feeds (full FeedData) for a voting round
+    function getProvenFeeds(
+        uint32 votingRoundId
+    ) external view returns (TestFtsoV2Interface.FeedData[] memory) {
+        bytes21[] memory ids = _provenFeedIdsByRound[votingRoundId];
+        TestFtsoV2Interface.FeedData[]
+            memory out = new TestFtsoV2Interface.FeedData[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            out[i] = provenFeeds[votingRoundId][ids[i]];
+        }
+        return out;
+    }
+}

--- a/scripts/fetchAndVerifyAnchorFeed.ts
+++ b/scripts/fetchAndVerifyAnchorFeed.ts
@@ -1,0 +1,138 @@
+import { run } from "hardhat";
+import { FtsoV2AnchorFeedConsumerContract } from "../typechain-types";
+
+// Feed IDs, see https://dev.flare.network/ftso/scaling/anchor-feeds for full list
+const FEED_IDS = [
+    "0x01464c522f55534400000000000000000000000000", // FLR/USD
+    "0x014254432f55534400000000000000000000000000", // BTC/USD
+    "0x014554482f55534400000000000000000000000000", // ETH/USD
+];
+
+// Structs our contract is expecting
+type FeedData = {
+    votingRoundId: number;
+    id: string;
+    value: number;
+    turnoutBIPS: number;
+    decimals: number;
+};
+
+type FeedDataWithProof = {
+    proof: string[];
+    body: FeedData;
+};
+
+// Helper function decoding the Hex of the FeedId for demonstration purposes
+// Format: [0xCC][ASCII(label)][0x00 padding] where CC is category (e.g., 0x01 = Crypto)
+function decodeFeedId(idHex: string): { categoryByte: number; category: string; label: string } {
+    const hex = idHex.startsWith("0x") ? idHex.slice(2) : idHex;
+    const bytes = Buffer.from(hex, "hex");
+    if (bytes.length !== 21) return { categoryByte: NaN, category: "Unknown", label: idHex };
+    const categoryByte = bytes[0];
+    // label is ASCII from index 1 until first 0x00
+    let end = bytes.length;
+    for (let i = 1; i < bytes.length; i++) {
+        if (bytes[i] === 0x00) {
+            end = i;
+            break;
+        }
+    }
+    const label = bytes.slice(1, end).toString("ascii");
+    const category = categoryByte === 0x01 ? "Crypto" : `0x${categoryByte.toString(16).padStart(2, "0")}`;
+    return { categoryByte, category, label: label || idHex };
+}
+
+/**
+ * Fetches anchor feed data from the DA Layer.
+ */
+async function fetchAnchorFeeds(): Promise<string> {
+    // Fetching the anchor feeds from the Data Availability Layer
+    // Note: this request will default to the latest voting round id if none is specified
+    const daLayerProofsUrl = `${process.env.COSTON2_DA_LAYER_URL}/api/v0/ftso/anchor-feeds-with-proof`;
+
+    try {
+        const res = await fetch(daLayerProofsUrl, {
+            method: "POST",
+            headers: { "x-apikey": process.env.X_API_KEY, "Content-Type": "application/json" },
+            body: JSON.stringify({ feed_ids: FEED_IDS }),
+        });
+        const text = await res.text();
+        console.log("DA Layer raw response:", text);
+        if (!res.ok) throw new Error(`DA layer returned ${res.status}: ${text}`);
+        return text;
+    } catch (e) {
+        console.error("Error fetching anchor feeds:", e);
+        throw e;
+    }
+}
+
+/**
+ * Deploys the FtsoV2AnchorFeedConsumer contract.
+ */
+async function deployConsumerContract() {
+    const FtsoV2AnchorFeedConsumer = await artifacts.require("FtsoV2AnchorFeedConsumer");
+    const feedConsumer = await FtsoV2AnchorFeedConsumer.new();
+    try {
+        await run("verify:verify", {
+            address: feedConsumer.address,
+            constructorArguments: [],
+        });
+    } catch (e: any) {
+        console.log(e);
+    }
+    console.log("FtsoV2AnchorFeedConsumer deployed at:", feedConsumer.address);
+    return feedConsumer;
+}
+
+async function interactWithContract(
+    feedConsumer: FtsoV2AnchorFeedConsumerContract,
+    feedDataWithProof: FeedDataWithProof
+) {
+    await feedConsumer.savePrice([
+        feedDataWithProof.proof,
+        [
+            feedDataWithProof.body.votingRoundId,
+            feedDataWithProof.body.id,
+            feedDataWithProof.body.value,
+            feedDataWithProof.body.turnoutBIPS,
+            feedDataWithProof.body.decimals,
+        ],
+    ]);
+    const saved = await feedConsumer.provenFeeds(feedDataWithProof.body.votingRoundId, feedDataWithProof.body.id);
+    const formattedPrice = Number(saved.value) * Math.pow(10, -Number(saved.decimals));
+    const { label, category } = decodeFeedId(feedDataWithProof.body.id);
+    console.log(
+        `Saved price: ${formattedPrice} ${label} [${category}] at voting round: ${saved.votingRoundId.toString()}`
+    );
+
+    console.log("\n\n");
+    console.log("Proven feeds:", await feedConsumer.getProvenFeeds(feedDataWithProof.body.votingRoundId));
+    console.log("Proven feed ids:", await feedConsumer.getProvenFeedIds(feedDataWithProof.body.votingRoundId));
+}
+
+async function main() {
+    // Fetch data from the Data Availability Layer
+    const rawResponse = await fetchAnchorFeeds();
+
+    // Deploy the consumer contract
+    const feedConsumer = await deployConsumerContract();
+
+    // Process each feed
+    const feedsFromDALayer = JSON.parse(rawResponse) as any[];
+    for (const feed of feedsFromDALayer) {
+        const body = feed?.body ?? feed?.data;
+        const proof = feed?.proof as string[] | undefined;
+        if (!body || !Array.isArray(proof)) {
+            console.warn(`Skipping malformed data from DA: ${JSON.stringify(feed)}`);
+            continue;
+        }
+
+        await interactWithContract(feedConsumer, { proof, body } as FeedDataWithProof);
+    }
+
+    process.exit(0);
+}
+
+main().catch(e => {
+    console.error(e);
+});


### PR DESCRIPTION
This PR adds an easier to understand "fetch and verify" script to query the DA layer for specific price feeds and verify them on-chain. Additionally, it includes decoding of feedIds for demonstration purposes of how they work.

The other anchor script, `getAnchorPrices.ts` has no on-chain component which is why I am making this PR.